### PR TITLE
Remove unnecessarily strict node & npm version pinning

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "author": "Dave Sag <davesag@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": "10.8.0",
-    "npm": "6.2.0"
+    "node": ">=10.0.0"
   },
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Adding the dependency to my project fails, because I run a newer version of node.
The engine pinning should be less strict. In my pull request I removed the npm version pinning and changed the node version pinning to `>=10.0.0`.

Even that might be too strict, but I am not entirely aware of the changes between node majors.