### PR TITLE
[feature, documentation, #100] document custom models folder and allow custom suffix

### DIFF
--- a/src/mockModels.js
+++ b/src/mockModels.js
@@ -1,12 +1,11 @@
 const fs = require('fs')
 const path = require('path')
-
 const fileFilter = require('./utils/fileFilter')
 
-const projectRoot = process.cwd()
+const PROJECT_ROOT = process.cwd()
 
 let sequelizerc
-const sequelizercPath = path.join(projectRoot, '.sequelizerc')
+const sequelizercPath = path.join(PROJECT_ROOT, '.sequelizerc')
 
 try {
   sequelizerc = require(sequelizercPath)
@@ -15,28 +14,33 @@ try {
   if (!err.code === 'MODULE_NOT_FOUND') throw err
 }
 
-const modelsFolder = sequelizerc
+const DEFAULT_SUFFIX = '.js'
+const DEFAULT_MODELS_FOLDER = sequelizerc
   ? /* istanbul ignore next */ sequelizerc['models-path']
-  : path.join(projectRoot, 'src', 'models')
+  : path.join(PROJECT_ROOT, 'src', 'models')
 
-const makeName = file => file.slice(0, -3)
+const makeName = suffix => file => file.slice(0, -suffix.length)
 
 const listToObject = (acc, elem) => {
   acc[elem] = elem
   return acc
 }
 
-/* istanbul ignore next */
-const listModels = (folder = modelsFolder) =>
+//
+const listModels = (
+  /* istanbul ignore next */ folder = DEFAULT_MODELS_FOLDER,
+  suffix = DEFAULT_SUFFIX
+) =>
   fs
     .readdirSync(folder)
-    .filter(fileFilter)
-    .map(makeName)
+    .filter(fileFilter(suffix))
+    .map(makeName(suffix))
 
-const finder = folder => listModels(folder).reduce(listToObject, {})
+const finder = (folder, suffix) =>
+  listModels(folder, suffix).reduce(listToObject, {})
 
-const makeMockModels = (models, folder) => ({
-  ...finder(folder),
+const makeMockModels = (models, folder, suffix) => ({
+  ...finder(folder, suffix),
   ...models,
   '@noCallThru': true
 })

--- a/src/utils/fileFilter.js
+++ b/src/utils/fileFilter.js
@@ -1,4 +1,6 @@
-const fileFilter = file =>
-  file.indexOf('.') !== 0 && file !== 'index.js' && file.slice(-3) === '.js'
+const fileFilter = suffix => file =>
+  file.indexOf('.') !== 0 &&
+  file !== `index${suffix}` &&
+  file.slice(-suffix.length) === suffix
 
 module.exports = fileFilter

--- a/test/unit/listModels.test.js
+++ b/test/unit/listModels.test.js
@@ -4,9 +4,19 @@ const { listModels } = require('../../src')
 
 describe('src/listModels', () => {
   const expected = ['HasHooks', 'Indexed', 'Simple']
-  const models = listModels('test/models')
+  context('default suffix', () => {
+    const models = listModels('test/models')
 
-  it('lists the models', () => {
-    expect(models).to.deep.equal(expected)
+    it('lists the models', () => {
+      expect(models).to.deep.equal(expected)
+    })
+  })
+
+  context('custom suffix', () => {
+    const models = listModels('test/models', '.js')
+
+    it('lists the models', () => {
+      expect(models).to.deep.equal(expected)
+    })
   })
 })

--- a/test/unit/makeMockModels.test.js
+++ b/test/unit/makeMockModels.test.js
@@ -3,17 +3,23 @@ const { expect } = require('chai')
 const { makeMockModels, listModels } = require('../../src')
 
 describe('src/makeMockModels', () => {
-  const mockModels = makeMockModels({ Fake: 'a fake' }, 'test/models')
-  const models = listModels('test/models')
+  const doTests = ([label, suffix]) => {
+    const mockModels = makeMockModels({ Fake: 'a fake' }, 'test/models', suffix)
+    const models = listModels('test/models', suffix)
 
-  const doTest = model => {
-    it(`has the model ${model}`, () => {
-      expect(mockModels).to.have.property(model)
+    context(label, () => {
+      const doTest = model => {
+        it(`has the model ${model}`, () => {
+          expect(mockModels).to.have.property(model)
+        })
+      }
+      ;[...models, 'Fake'].forEach(doTest)
+
+      it("adds '@noCallThru: true'", () => {
+        expect(mockModels).to.have.property('@noCallThru', true)
+      })
     })
   }
-  ;[...models, 'Fake'].forEach(doTest)
 
-  it("adds '@noCallThru: true'", () => {
-    expect(mockModels).to.have.property('@noCallThru', true)
-  })
+  ;[['default suffix'], ['custom suffix', '.js']].forEach(doTests)
 })

--- a/test/unit/utils/fileFilter.test.js
+++ b/test/unit/utils/fileFilter.test.js
@@ -6,6 +6,6 @@ describe('src/utils/fileFilter', () => {
   const expected = ['test.js']
 
   it('filters correctly', () => {
-    expect(input.filter(fileFilter)).to.deep.equal(expected)
+    expect(input.filter(fileFilter('.js'))).to.deep.equal(expected)
   })
 })


### PR DESCRIPTION
* now allow for customised models file suffixes
* add documentation on supplying customised models folder path and file suffix
* cleaned up example code in readme
