### PR TITLE
[feature, #115] testing models created with model.init

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const checkUniqueIndex = require('./checks/checkUniqueIndex')
 const dataTypes = require('./dataTypes')
 const sequelize = require('./sequelize')
 const { makeMockModels, listModels } = require('./mockModels')
+const Sequelize = require('./mockSequelize')
 
 module.exports = {
   checkHookDefined,
@@ -18,5 +19,6 @@ module.exports = {
   dataTypes,
   listModels,
   makeMockModels,
-  sequelize
+  sequelize,
+  Sequelize
 }

--- a/src/mockSequelize.js
+++ b/src/mockSequelize.js
@@ -1,0 +1,8 @@
+const { spy } = require('sinon')
+
+const DataTypes = require('./dataTypes')
+
+class Model {}
+Model.init = spy()
+
+module.exports = { Model, DataTypes }

--- a/test/unit/mockSequelize.test.js
+++ b/test/unit/mockSequelize.test.js
@@ -1,0 +1,23 @@
+const { expect } = require('chai')
+
+const Sequelize = require('../../src/mockSequelize')
+const DataTypes = require('../../src/dataTypes')
+
+describe('src/mockSequelize', () => {
+  it('has Model', () => {
+    expect(Sequelize).to.have.property('Model')
+  })
+
+  it('Model is a class', () => {
+    expect(Sequelize.Model).to.be.a('function')
+    expect(Sequelize.Model.constructor).to.be.a('function')
+  })
+
+  it('Model has a static init function', () => {
+    expect(Sequelize.Model.init).to.be.a('function')
+  })
+
+  it('has DataTypes', () => {
+    expect(Sequelize).to.have.property('DataTypes', DataTypes)
+  })
+})


### PR DESCRIPTION
Allows testing of a model that's been created by extending `Sequelize.Model` and invoking its static `init` function.

Example:

`src/models/User.js`

```js
onst { Model, DataTypes } = require('sequelize')

const factory = sequelize => {
  class User extends Model {}
  User.init(
    {
      firstName: DataTypes.STRING,
      lastName: DataTypes.STRING
    },
    { sequelize, modelName: 'User' }
  )
  return User
}

module.exports = factory
```

`test/unit/models/User.test.js`

```js
const { expect } = require('chai')
const { spy } = require('sinon')
const proxyquire = require('proxyquire')
const { sequelize, Sequelize } = require('sequelize-test-helpers')

describe('src/models/User', () => {
  const { DataTypes } = Sequelize

  const UserFactory = proxyquire('src/models/User', {
    sequelize: Sequelize
  })

  let User

  before(() => {
    User = UserFactory(sequelize)
  })

  // It's important you do this
  after(() => {
    User.init.resetHistory()
  })

  it('called User.init with the correct parameters', () => {
    expect(User.init).to.have.been.calledWith(
      {
        firstName: DataTypes.STRING,
        lastName: DataTypes.STRING
      },
      {
        sequelize,
        modelName: 'User'
      }
    )
  })
})
```

resolves issue #115 
