### PR TITLE
Add static methods as stubs

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1,6 +1,18 @@
 const sinon = require('sinon')
 const hooks = require('./constants/hooks')
 
+const STATICS_METHODS = [
+  'and',
+  'cast',
+  'col',
+  'fn',
+  'json',
+  'literal',
+  'or',
+  'useCLS',
+  'where'
+]
+
 const sequelize = {
   define: (modelName, modelDefn, metaData = {}) => {
     const model = function() {}
@@ -43,5 +55,9 @@ const sequelize = {
     return model
   }
 }
+
+STATICS_METHODS.forEach(method => {
+  sequelize[method] = sinon.stub()
+})
 
 module.exports = sequelize

--- a/test/unit/sequelize.test.js
+++ b/test/unit/sequelize.test.js
@@ -1,0 +1,28 @@
+const { expect } = require('chai')
+
+const sequelize = require('../../src/sequelize')
+
+const STATIC_METHODS = [
+  'and',
+  'cast',
+  'col',
+  'fn',
+  'json',
+  'literal',
+  'or',
+  'useCLS',
+  'where'
+]
+
+describe('src/sequelize', () => {
+  it('has define', () => {
+    expect(sequelize).to.have.property('define')
+    expect(sequelize.define).to.be.a('function')
+  })
+
+  STATIC_METHODS.forEach(method => {
+    it(`has static method ${method}`, () => {
+      expect(sequelize[method]).to.be.a('function')
+    })
+  })
+})


### PR DESCRIPTION
I got errors when when defining mock models with index definitions because of calls to `sequelize.fn` and `sequelize.col`.

In case it's useful to others, here's a PR adding stubs for these and the other sequelize static methods.