### PR TITLE
add Model association methods as spys to mockSequelize class

### DIFF
--- a/src/mockSequelize.js
+++ b/src/mockSequelize.js
@@ -4,5 +4,9 @@ const DataTypes = require('./dataTypes')
 
 class Model {}
 Model.init = spy()
+Model.belongsToMany = spy()
+Model.belongsTo = spy()
+Model.hasMany = spy()
+Model.hasOne = spy()
 
 module.exports = { Model, DataTypes }


### PR DESCRIPTION
sequelize-cli model generation uses the class + init pattern.  To enable testing of associations in models I added the four model class association methods (belongsToMany, belongsTo, hasOne, hasMany) to the mockSequelize class.