### PR TITLE
[Feature, #345] improve tests deprecate checkUniqueCompoundIndex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ typings/
 
 # macOS finder metadata
 .DS_Store
+
+# VS Code config
+.vscode/

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ const model = (sequelize, DataTypes) => {
     {
       indexes: [
         { unique: true, fields: ['email'] },
-        { unique: true, fields: ['token'] }
+        { unique: true, fields: ['token'] },
+        { unique: false, fields: ['firstName', 'lastName'] }
       ]
     }
   )
@@ -133,21 +134,32 @@ describe('src/models/User', () => {
   })
 
   context('indexes', () => {
-    ;['email', 'token'].forEach(checkUniqueIndex(user))
+    context('unique', () => {
+      ;['email', 'token'].forEach(checkUniqueIndex(user))
+    })
+
+    context('non unique (and also composite in this example)', () => {
+      ;[['firstname', 'lastname']].forEach(checkNonUniqueIndex(user))
+    })
   })
 })
 ```
 
 ### Built-in checks
 
-| Check                      | What it does                                             |
-| -------------------------- | -------------------------------------------------------- |
-| `checkHookDefined`         | Checks that a particular hook is defined.                |
-| `checkModelName`           | Checks that the model is named correctly.                |
-| `checkNonUniqueIndex`      | Checks that a specific non-unique index is defined.      |
-| `checkPropertyExists`      | Checks that the model has defined the given property.    |
-| `checkUniqueCompoundIndex` | Checks that a specific unique compound index is defined. |
-| `checkUniqueIndex`         | Checks that a specific unique index is defined.          |
+| Check                 | What it does                                          |
+| --------------------- | ----------------------------------------------------- |
+| `checkHookDefined`    | Checks that a particular hook is defined.             |
+| `checkModelName`      | Checks that the model is named correctly.             |
+| `checkNonUniqueIndex` | Checks that a specific non-unique index is defined.   |
+| `checkPropertyExists` | Checks that the model has defined the given property. |
+| `checkUniqueIndex`    | Checks that a specific unique index is defined.       |
+
+#### Deprecation notice
+
+| Check                      | Note                                                   |
+| -------------------------- | ------------------------------------------------------ |
+| `checkUniqueCompoundIndex` | Use either `checkUniqueIndex` or `checkNonUniqueIndex` |
 
 ### Checking associations
 

--- a/src/checks/checkNonUniqueIndex.js
+++ b/src/checks/checkNonUniqueIndex.js
@@ -1,7 +1,7 @@
 const { checkSingleIndex, checkAllIndexes } = require('./utils')
 
-const checkSingleNonUniqueIndex = instance => checkSingleIndex(instance, false)
-const checkAllNonUniqueIndexes = instance => checkAllIndexes(instance, false)
+const checkSingleNonUniqueIndex = instance => checkSingleIndex(instance)
+const checkAllNonUniqueIndexes = instance => checkAllIndexes(instance)
 
 const checkNonUniqueIndex = instance => indexName =>
   Array.isArray(indexName)

--- a/src/checks/checkNonUniqueIndex.js
+++ b/src/checks/checkNonUniqueIndex.js
@@ -1,10 +1,11 @@
-const { expect } = require('chai')
+const { checkSingleIndex, checkAllIndexes } = require('./utils')
 
-const checkNonUniqueIndex = instance => indexName => {
-  it(`indexed a non-unique ${indexName}`, () => {
-    expect(instance.indexes.find(index => index.unique === false && index.fields[0] === indexName))
-      .not.to.be.undefined
-  })
-}
+const checkSingleNonUniqueIndex = instance => checkSingleIndex(instance, false)
+const checkAllNonUniqueIndexes = instance => checkAllIndexes(instance, false)
+
+const checkNonUniqueIndex = instance => indexName =>
+  Array.isArray(indexName)
+    ? checkAllNonUniqueIndexes(instance)(indexName)
+    : checkSingleNonUniqueIndex(instance)(indexName)
 
 module.exports = checkNonUniqueIndex

--- a/src/checks/checkNonUniqueIndex.js
+++ b/src/checks/checkNonUniqueIndex.js
@@ -1,11 +1,5 @@
-const { checkSingleIndex, checkAllIndexes } = require('./utils')
+const { checkIndex } = require('./utils')
 
-const checkSingleNonUniqueIndex = instance => checkSingleIndex(instance)
-const checkAllNonUniqueIndexes = instance => checkAllIndexes(instance)
-
-const checkNonUniqueIndex = instance => indexName =>
-  Array.isArray(indexName)
-    ? checkAllNonUniqueIndexes(instance)(indexName)
-    : checkSingleNonUniqueIndex(instance)(indexName)
+const checkNonUniqueIndex = instance => indexName => checkIndex(instance, indexName)
 
 module.exports = checkNonUniqueIndex

--- a/src/checks/checkUniqueCompoundIndex.js
+++ b/src/checks/checkUniqueCompoundIndex.js
@@ -1,10 +1,13 @@
 const { expect } = require('chai')
 
-const checkUniqueCompoundIndex = instance => indecies => {
-  it(`indexed a unique index of ${indecies.join(' and ')}`, () => {
+/**
+ * @deprecated both `checkUniqueIndex` and `checkNonUniqueIndex` will now check for either simple or composite indexes.
+ */
+const checkUniqueCompoundIndex = instance => indexes => {
+  it(`indexed a unique index of ${indexes.join(' and ')}`, () => {
     expect(
       instance.indexes.find(
-        index => index.unique === true && index.fields.join('') === indecies.join('')
+        index => index.unique === true && index.fields.join('') === indexes.join('')
       )
     ).not.to.be.undefined
   })

--- a/src/checks/checkUniqueIndex.js
+++ b/src/checks/checkUniqueIndex.js
@@ -1,10 +1,11 @@
-const { expect } = require('chai')
+const { checkSingleIndex, checkAllIndexes } = require('./utils')
 
-const checkUniqueIndex = instance => indexName => {
-  it(`indexed a unique ${indexName}`, () => {
-    expect(instance.indexes.find(index => index.unique === true && index.fields[0] === indexName))
-      .not.to.be.undefined
-  })
-}
+const checkSingleUniqueIndex = instance => checkSingleIndex(instance, true)
+const checkAllUniqueIndexes = instance => checkAllIndexes(instance, true)
+
+const checkUniqueIndex = instance => indexName =>
+  Array.isArray(indexName)
+    ? checkAllUniqueIndexes(instance)(indexName)
+    : checkSingleUniqueIndex(instance)(indexName)
 
 module.exports = checkUniqueIndex

--- a/src/checks/checkUniqueIndex.js
+++ b/src/checks/checkUniqueIndex.js
@@ -1,11 +1,5 @@
-const { checkSingleIndex, checkAllIndexes } = require('./utils')
+const { checkIndex } = require('./utils')
 
-const checkSingleUniqueIndex = instance => checkSingleIndex(instance, true)
-const checkAllUniqueIndexes = instance => checkAllIndexes(instance, true)
-
-const checkUniqueIndex = instance => indexName =>
-  Array.isArray(indexName)
-    ? checkAllUniqueIndexes(instance)(indexName)
-    : checkSingleUniqueIndex(instance)(indexName)
+const checkUniqueIndex = instance => indexName => checkIndex(instance, indexName, true)
 
 module.exports = checkUniqueIndex

--- a/src/checks/utils.js
+++ b/src/checks/utils.js
@@ -1,0 +1,30 @@
+const { expect } = require('chai')
+
+const checkSingleIndex =
+  (instance, unique = false) =>
+  indexName => {
+    it(`indexed a unique ${indexName}`, () => {
+      expect(
+        instance.indexes.find(index => index.unique === unique && index.fields[0] === indexName)
+      ).not.to.be.undefined
+    })
+  }
+
+const checkAllIndexes =
+  (instance, unique = false) =>
+  indexNames => {
+    context(`indexed a unique composite of [${indexNames.join(', ')}]`, () => {
+      indexNames.forEach((indexName, i) => {
+        it(`includes ${indexName} at ${i}`, () => {
+          expect(
+            instance.indexes.find(index => index.unique === unique && index.fields[i] === indexName)
+          ).not.to.be.undefined
+        })
+      })
+    })
+  }
+
+module.exports = {
+  checkSingleIndex,
+  checkAllIndexes
+}

--- a/src/checks/utils.js
+++ b/src/checks/utils.js
@@ -19,9 +19,10 @@ const checkAllIndexes = (instance, unique) => indexNames => {
   })
 }
 
-const checkIndex = (instance, indexNameOrNames, unique = false) => {
-  const checkFn = Array.isArray(indexNameOrNames) ? checkAllIndexes : checkSingleIndex
-  return checkFn(instance, unique)(indexNameOrNames)
-}
+const checkIndex = (instance, indexNameOrNames, unique = false) =>
+  (Array.isArray(indexNameOrNames) ? checkAllIndexes : checkSingleIndex)(
+    instance,
+    unique
+  )(indexNameOrNames)
 
 module.exports = { checkIndex }

--- a/src/checks/utils.js
+++ b/src/checks/utils.js
@@ -1,30 +1,27 @@
 const { expect } = require('chai')
 
-const checkSingleIndex =
-  (instance, unique = false) =>
-  indexName => {
-    it(`indexed a unique ${indexName}`, () => {
-      expect(
-        instance.indexes.find(index => index.unique === unique && index.fields[0] === indexName)
-      ).not.to.be.undefined
-    })
-  }
+const checkSingleIndex = (instance, unique) => indexName => {
+  it(`indexed a unique ${indexName}`, () => {
+    expect(instance.indexes.find(index => index.unique === unique && index.fields[0] === indexName))
+      .not.to.be.undefined
+  })
+}
 
-const checkAllIndexes =
-  (instance, unique = false) =>
-  indexNames => {
-    context(`indexed a unique composite of [${indexNames.join(', ')}]`, () => {
-      indexNames.forEach((indexName, i) => {
-        it(`includes ${indexName} at ${i}`, () => {
-          expect(
-            instance.indexes.find(index => index.unique === unique && index.fields[i] === indexName)
-          ).not.to.be.undefined
-        })
+const checkAllIndexes = (instance, unique) => indexNames => {
+  context(`indexed a unique composite of [${indexNames.join(', ')}]`, () => {
+    indexNames.forEach((indexName, i) => {
+      it(`includes ${indexName} at ${i}`, () => {
+        expect(
+          instance.indexes.find(index => index.unique === unique && index.fields[i] === indexName)
+        ).not.to.be.undefined
       })
     })
-  }
-
-module.exports = {
-  checkSingleIndex,
-  checkAllIndexes
+  })
 }
+
+const checkIndex = (instance, indexNameOrNames, unique = false) => {
+  const checkFn = Array.isArray(indexNameOrNames) ? checkAllIndexes : checkSingleIndex
+  return checkFn(instance, unique)(indexNameOrNames)
+}
+
+module.exports = { checkIndex }

--- a/test/models/Indexed.js
+++ b/test/models/Indexed.js
@@ -10,13 +10,15 @@ const model = (sequelize, DataTypes) => {
         }
       },
       lunch: DataTypes.STRING,
+      coffee: DataTypes.STRING,
       uuid: DataTypes.UUID
     },
     {
       indexes: [
         { unique: true, fields: ['uuid'] },
         { unique: false, fields: ['name'] },
-        { unique: true, fields: ['name', 'lunch'] }
+        { unique: true, fields: ['name', 'lunch'] },
+        { unique: false, fields: ['coffee', 'lunch'] }
       ]
     }
   )

--- a/test/unit/checks/checkHookDefined.test.js
+++ b/test/unit/checks/checkHookDefined.test.js
@@ -6,6 +6,7 @@ describe('src/checkHookDefined', () => {
   context('when hooks are defined', () => {
     const Model = HasHooksModel(sequelize, dataTypes)
     const instance = new Model()
+
     ;['beforeValidate', 'afterValidate', 'afterCreate'].forEach(checkHookDefined(instance))
   })
 

--- a/test/unit/checks/checkModelName.test.js
+++ b/test/unit/checks/checkModelName.test.js
@@ -4,6 +4,7 @@ const SimpleModel = require('../../models/Simple')
 
 describe('src/checkModelName', () => {
   const Model = SimpleModel(sequelize, dataTypes)
+
   context('happy path', () => {
     checkModelName(Model)('Simple')
   })

--- a/test/unit/checks/checkNonUniqueIndex.test.js
+++ b/test/unit/checks/checkNonUniqueIndex.test.js
@@ -6,8 +6,9 @@ const IndexedModel = require('../../models/Indexed')
 describe('src/checkNonUniqueIndex', () => {
   const Model = IndexedModel(sequelize, dataTypes)
   const instance = new Model()
+
   context('happy path', () => {
-    ;['name'].forEach(checkNonUniqueIndex(instance))
+    ;['name', ['coffee', 'lunch']].forEach(checkNonUniqueIndex(instance))
   })
 
   context('unhappy path', () => {

--- a/test/unit/checks/checkPropertyExists.test.js
+++ b/test/unit/checks/checkPropertyExists.test.js
@@ -6,6 +6,7 @@ const SimpleModel = require('../../models/Simple')
 describe('src/checkPropertyExists', () => {
   const Model = SimpleModel(sequelize, dataTypes)
   const instance = new Model()
+
   context('happy path', () => {
     ;['name'].forEach(checkPropertyExists(instance))
   })

--- a/test/unit/checks/checkUniqueCompoundIndex.test.js
+++ b/test/unit/checks/checkUniqueCompoundIndex.test.js
@@ -6,6 +6,7 @@ const IndexedModel = require('../../models/Indexed')
 describe('src/checkUniqueCompoundIndex', () => {
   const Model = IndexedModel(sequelize, dataTypes)
   const instance = new Model()
+
   context('happy path', () => {
     ;[['name', 'lunch']].forEach(checkUniqueCompoundIndex(instance))
   })

--- a/test/unit/checks/checkUniqueIndex.test.js
+++ b/test/unit/checks/checkUniqueIndex.test.js
@@ -8,7 +8,7 @@ describe('src/checkUniqueIndex', () => {
   const instance = new Model()
 
   context('happy path', () => {
-    ;['uuid'].forEach(checkUniqueIndex(instance))
+    ;['uuid', ['name', 'lunch']].forEach(checkUniqueIndex(instance))
   })
 
   context('unhappy path', () => {


### PR DESCRIPTION
- improve tests
- updated docs
- made `checkUniqueIndex` and `checkNonUniqueIndex` work in the same way and accept an array of field names as well as just a single field name
- deprecated `checkUniqueCompoundIndex`
