### PR TITLE
[feature, #348] index unique value now can be falsy and improved the wording of …

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,4 +15,4 @@ You can expect to get an update on a reported vulnerability within 2 working day
 
 ## Vulnerabilities in development dependencies
 
-I'm using `dependabot` to scan for security issues and update dependencies in the `develop` branch regularly.
+I'm using `dependabot` and `snyk` to scan for security issues and I update dependencies in the `develop` branch regularly.

--- a/src/checks/checkHookDefined.js
+++ b/src/checks/checkHookDefined.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai')
 
 const checkHookDefined = instance => hookName => {
-  it(`defined a ${hookName} hook`, () => {
+  it(`defined the ${hookName} hook`, () => {
     expect(instance.hooks[hookName]).to.be.a('function')
   })
 }

--- a/src/checks/checkUniqueCompoundIndex.js
+++ b/src/checks/checkUniqueCompoundIndex.js
@@ -1,10 +1,11 @@
 const { expect } = require('chai')
+const { serialCommaList } = require('../utils')
 
 /**
  * @deprecated both `checkUniqueIndex` and `checkNonUniqueIndex` will now check for either simple or composite indexes.
  */
 const checkUniqueCompoundIndex = instance => indexes => {
-  it(`indexed a unique index of ${indexes.join(' and ')}`, () => {
+  it(`indexed an unique index of ${serialCommaList(indexes)}`, () => {
     expect(
       instance.indexes.find(
         index => index.unique === true && index.fields.join('') === indexes.join('')

--- a/src/checks/utils.js
+++ b/src/checks/utils.js
@@ -1,18 +1,29 @@
 const { expect } = require('chai')
+const { serialCommaList } = require('../utils')
+
+// if unique is true then expect index.unique to be true too, but
+// if unique is false then index.unique can simply be be falsy
+const matchUniqueness = (index, unique) => (unique ? index.unique === unique : !index.unique)
+const prefix = unique => (unique ? 'n ' : ' non-')
 
 const checkSingleIndex = (instance, unique) => indexName => {
-  it(`indexed a unique ${indexName}`, () => {
-    expect(instance.indexes.find(index => index.unique === unique && index.fields[0] === indexName))
-      .not.to.be.undefined
+  it(`indexed a${prefix(unique)}unique ${indexName}`, () => {
+    expect(
+      instance.indexes.find(
+        index => matchUniqueness(index, unique) && index.fields[0] === indexName
+      )
+    ).not.to.be.undefined
   })
 }
 
 const checkAllIndexes = (instance, unique) => indexNames => {
-  context(`indexed a unique composite of [${indexNames.join(', ')}]`, () => {
+  context(`indexed a${prefix(unique)}unique composite of [${serialCommaList(indexNames)}]`, () => {
     indexNames.forEach((indexName, i) => {
       it(`includes ${indexName} at ${i}`, () => {
         expect(
-          instance.indexes.find(index => index.unique === unique && index.fields[i] === indexName)
+          instance.indexes.find(
+            index => matchUniqueness(index, unique) && index.fields[i] === indexName
+          )
         ).not.to.be.undefined
       })
     })

--- a/src/mockModels.js
+++ b/src/mockModels.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const fileFilter = require('./utils/fileFilter')
+const { fileFilter } = require('./utils')
 
 const PROJECT_ROOT = process.cwd()
 

--- a/src/utils/fileFilter.js
+++ b/src/utils/fileFilter.js
@@ -1,3 +1,9 @@
+/**
+ * Returns a file filter function that removes the given suffix before comparing file names
+ *
+ * @param {*} suffix '.js' or '.jsx' etc.
+ * @returns {Function} a function that can be supplied to `array.filter` to filter an array of file names
+ */
 const fileFilter = suffix => file =>
   file.indexOf('.') !== 0 && file !== `index${suffix}` && file.slice(-suffix.length) === suffix
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,4 @@
+const fileFilter = require('./fileFilter')
+const serialCommaList = require('./serialCommaList')
+
+module.exports = { fileFilter, serialCommaList }

--- a/src/utils/serialCommaList.js
+++ b/src/utils/serialCommaList.js
@@ -1,0 +1,21 @@
+const oxford = words => `${words.slice(0, -1).join(', ')}, and ${words[words.length - 1]}`
+
+/**
+ * Returns a formatted list of words, separated by commas
+ * as per the Oxford (aka serial) Comma rules.
+ *
+ * https://en.wikipedia.org/wiki/Serial_comma
+ *
+ * @param {array} words The array of words
+ * @returns {string} A list of words with an Oxford comma as appropriate
+ */
+const serialCommaList = words =>
+  Array.isArray(words) && words.length
+    ? words.length === 1
+      ? words[0]
+      : words.length === 2
+      ? `${words[0]} and ${words[1]}`
+      : oxford(words)
+    : words
+
+module.exports = serialCommaList

--- a/test/models/Indexed.js
+++ b/test/models/Indexed.js
@@ -18,7 +18,7 @@ const model = (sequelize, DataTypes) => {
         { unique: true, fields: ['uuid'] },
         { unique: false, fields: ['name'] },
         { unique: true, fields: ['name', 'lunch'] },
-        { unique: false, fields: ['coffee', 'lunch'] }
+        { fields: ['coffee', 'lunch'] } // leave out index: false here to test falsiness
       ]
     }
   )

--- a/test/unit/utils/fileFilter.test.js
+++ b/test/unit/utils/fileFilter.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai')
-const fileFilter = require('../../../src/utils/fileFilter')
+const { fileFilter } = require('../../../src/utils')
 
 describe('src/utils/fileFilter', () => {
   const input = ['test.js', 'skip-this', 'index.js', '.skip.this.js']

--- a/test/unit/utils/serialCommaList.test.js
+++ b/test/unit/utils/serialCommaList.test.js
@@ -1,0 +1,18 @@
+const { expect } = require('chai')
+const { serialCommaList } = require('../../../src/utils')
+
+describe('src/utils/serialCommaList', () => {
+  const doTest = ([words, expected]) => {
+    it(`displays '${words}' as '${expected}'`, () => {
+      expect(serialCommaList(words)).to.equal(expected)
+    })
+  }
+
+  ;[
+    [undefined, undefined],
+    ['not an array', 'not an array'],
+    [['alice'], 'alice'],
+    [['alice', 'bob'], 'alice and bob'],
+    [['alice', 'bob', 'charlie'], 'alice, bob, and charlie']
+  ].forEach(doTest)
+})


### PR DESCRIPTION
- index unique value now can be falsy,
- improved the wording of the test outputs when there are more than two fields in a compound index
- some minor refactoring
- added `snyk` to security doc

